### PR TITLE
Multiple fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ terraform.rc
 vendor/
 terraform-provider-silk
 main.tf
+terraform-provider-silk_*

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=silk.us
 NAMESPACE=silk-terraform-provider
 NAME=silk
 BINARY=terraform-provider-${NAME}
-VERSION=1.1.0
+VERSION=1.2.0
 OS_ARCH=linux_amd64
 
 default: install

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ release:
 
 
 install: build
-	mkdir -p mkdir ~/.terraform.d/plugins/localdomain/provider/silk/${VERSION}/linux_amd64
+	mkdir -p ~/.terraform.d/plugins/localdomain/provider/silk/${VERSION}/linux_amd64
 	mv ${BINARY} ~/.terraform.d/plugins/localdomain/provider/silk/${VERSION}/linux_amd64
 	
 

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ release:
 
 install: build
 	mkdir -p ~/.terraform.d/plugins/localdomain/provider/silk/${VERSION}/linux_amd64
-	mv ${BINARY} ~/.terraform.d/plugins/localdomain/provider/silk/${VERSION}/linux_amd64
-	
+	cp ${BINARY} ~/.terraform.d/plugins/localdomain/provider/silk/${VERSION}/linux_amd64
+	mv ${BINARY} ${BINARY}_${VERSION}_${OS_ARCH}
 
 test: 
 	go test -i $(TEST) || exit 1                                                   

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.0
-	github.com/silk-us/silk-sdp-go-sdk v1.0.9
+	github.com/silk-us/silk-sdp-go-sdk v1.1.1
 )
 
 

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/silk-us/silk-sdp-go-sdk v1.1.1
 )
 
-
-//replace (
-//	github.com/silk-us/silk-sdp-go-sdk => /mnt/d/Dropbox/SDP-Terraform/PC/silk-sdp-go-sdk
-//)
- 
+replace (
+	// github.com/silk-us/silk-sdp-go-sdk => /mnt/d/Dropbox/SDP-Terraform/PC/silk-sdp-go-sdk
+	github.com/silk-us/silk-sdp-go-sdk => ../silk-sdp-go-sdk
+)

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/silk-us/silk-sdp-go-sdk v1.0.8 h1:2hLQNQRkV3a7wF4Yy7zD6ELmTrh+tryfBWd
 github.com/silk-us/silk-sdp-go-sdk v1.0.8/go.mod h1:9zgQmOCTocQgEs3iRbPnsFQ9eXnsx64DLzwUMdpJucA=
 github.com/silk-us/silk-sdp-go-sdk v1.0.9 h1:ui2QPNt7Qjn2TYcE2CSXfITCtd17KX4lrmcV/hfwZNU=
 github.com/silk-us/silk-sdp-go-sdk v1.0.9/go.mod h1:9zgQmOCTocQgEs3iRbPnsFQ9eXnsx64DLzwUMdpJucA=
+github.com/silk-us/silk-sdp-go-sdk v1.0.10 h1:P22x3K/TxVDC746iBByu6c6UmgqrnTSN31EPjjQqDeo=
+github.com/silk-us/silk-sdp-go-sdk v1.0.10/go.mod h1:9zgQmOCTocQgEs3iRbPnsFQ9eXnsx64DLzwUMdpJucA=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/silk/config.go
+++ b/silk/config.go
@@ -25,3 +25,15 @@ func find(slice []string, val string) (int, bool) {
 	}
 	return -1, false
 }
+
+func unique(stringSlice []string) []string {
+    keys := make(map[string]bool)
+    list := []string{}	
+    for _, entry := range stringSlice {
+        if _, value := keys[entry]; !value {
+            keys[entry] = true
+            list = append(list, entry)
+        }
+    }    
+    return list
+}

--- a/silk/resource_silk_host.go
+++ b/silk/resource_silk_host.go
@@ -264,37 +264,22 @@ func resourceSilkHostUpdate(ctx context.Context, d *schema.ResourceData, m inter
 			}
 		}
 
-	}
-
 	if d.HasChange("iqn") {
 
 		c, n := d.GetChange("iqn")
 
-		// There was a change the current value is blank so we know an IQN needs to be added
-		if c.(string) == "" {
-			_, err := silk.CreateHostIQN(d.Get("name").(string), d.Get("iqn").(string), timeout)
+		if c.(string) != "" {
+		_, err := silk.DeleteHostIQN(currentHostName, timeout)
 			if err != nil {
 				return diag.FromErr(err)
 			}
-		} else {
-			// There was change and the current IQN is not blank so know we need to either remove
-			// or changed the IQN
-
-			// No mater the situation we are going to need to remove
-			// the IQN from the Host (i.e in order to change we have to first remove)
-			_, err := silk.DeleteHostIQN(d.Get("name").(string), timeout)
-			if err != nil {
-				return diag.FromErr(err)
 			}
 
-			// The new value is not blank so we know its an 'update' scenario
 			if n.(string) != "" {
-				_, err := silk.CreateHostIQN(d.Get("name").(string), d.Get("iqn").(string), timeout)
+			_, err := silk.CreateHostIQN(currentHostName, d.Get("iqn").(string), timeout)
 				if err != nil {
 					return diag.FromErr(err)
 				}
-			}
-
 		}
 
 	}

--- a/silk/resource_silk_volume.go
+++ b/silk/resource_silk_volume.go
@@ -363,7 +363,7 @@ func resourceSilkVolumeUpdate(ctx context.Context, d *schema.ResourceData, m int
 			_, foundInNew := find(new, h)
 			_, foundInCurrent := find(current, h)
 			if foundInNew && !foundInCurrent {
-				hostGroupMappingToRemove = append(hostGroupMappingToRemove, h)
+				hostGroupMappingToAdd = append(hostGroupMappingToAdd, h)
 			} else if !foundInNew && foundInCurrent {
 				hostGroupMappingToRemove = append(hostGroupMappingToRemove, h)
 			} 

--- a/silk/resource_silk_volume.go
+++ b/silk/resource_silk_volume.go
@@ -40,6 +40,11 @@ func resourceSilkVolume() *schema.Resource {
 				Required:    true,
 				Description: "The size, in GB, of the Volume.",
 			},
+			"volume_group_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "VolumeGroup ID (only used when renaming volumegroup name)",
+			},
 			"volume_group_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -179,6 +184,7 @@ func resourceSilkVolumeRead(ctx context.Context, d *schema.ResourceData, m inter
 
 			for _, volumeGroup := range getVolumeGroups.Hits {
 				if volumeGroup.ID == volumeGroupRefID {
+					d.Set("volume_group_id",volumeGroupRefID)
 					d.Set("volume_group_name", volumeGroup.Name)
 				}
 			}
@@ -247,19 +253,34 @@ func resourceSilkVolumeUpdate(ctx context.Context, d *schema.ResourceData, m int
 	timeout := d.Get("timeout").(int)
 
 	config := map[string]interface{}{}
-	var volumeName string
+	var currentVolumeName string
 
 	if d.HasChange("name") {
-		if d.HasChange("volume_group_name") {
-			return diag.Errorf("The volume name cannot be changed while moving to another Volume Group")
-		}
+		// if d.HasChange("volume_group_name") {
+		// 	return diag.Errorf("The volume name cannot be changed while moving to another Volume Group")
+		// }
+
 		config["name"] = d.Get("name").(string)
+
 		// If the name changed in Terraform, we need to look up the "original" name (i.e what is currently is on the Silk server)
 		// to push the new name change to the volume
-		currentVolumeName, _ := d.GetChange("name")
-		volumeName = currentVolumeName.(string)
+		oldVolumeName, _ := d.GetChange("name")
+		currentVolumeName = oldVolumeName.(string)
+
+		// // If the name changed in Terraform, we need to look up the "original" name (i.e what is currently is on the Silk server)
+		// // to push the new name change to the volume
+		// currentVolumeName, _ := d.GetChange("name")
+		// volumeName = currentVolumeName.(string)
+		// nameChangeConfig := map[string]interface{}{
+		// 	"name":d.Get("name").(string),
+		// }
+		// _, err := silk.UpdateVolume(volumeName, nameChangeConfig, timeout)
+		// if err != nil {
+		// 	d.Set("name",volumeName)
+		// 	return diag.FromErr(err)
+		// }
 	} else {
-		volumeName = d.Get("name").(string)
+		currentVolumeName = d.Get("name").(string)
 	}
 
 	hostMappingToRemove := []string{}
@@ -285,40 +306,30 @@ func resourceSilkVolumeUpdate(ctx context.Context, d *schema.ResourceData, m int
 			new = append(new, nReflect.Index(i).Interface().(string))
 		}
 
-		// Mapping Hosts
-		if len(current) < len(new) {
-			// Find all hosts that have been added to the host slice
-			for _, h := range new {
-				_, found := find(current, h)
-				if !found {
-					hostMappingToAdd = append(hostMappingToAdd, h)
-				}
+		union := unique(append(current, new... ))
+		for _, h := range union {
+			_, foundInNew := find(new, h)
+			_, foundInCurrent := find(current, h)
+			if foundInNew && !foundInCurrent {
+				hostMappingToAdd = append(hostMappingToAdd, h)
+			} else if !foundInNew && foundInCurrent {
+				hostMappingToRemove = append(hostMappingToRemove, h)
+			} 
+		}
+
+		// Add each Host to the Volume
+		for _, h := range hostMappingToAdd {
+			_, err := silk.CreateHostVolumeMapping(h, currentVolumeName)
+			if err != nil {
+				return diag.FromErr(err)
 			}
+		}
 
-			// Add each Host to the Volume
-			for _, h := range hostMappingToAdd {
-				_, err := silk.CreateHostVolumeMapping(h, d.Get("name").(string))
-				if err != nil {
-					return diag.FromErr(err)
-				}
-			}
-
-		} else {
-
-			// Find all Hosts that have been removed from the host_mapping slice
-			for _, h := range current {
-				_, found := find(new, h)
-				if !found {
-					hostMappingToRemove = append(hostMappingToRemove, h)
-				}
-			}
-
-			// Remove each Host from the Volume
-			for _, h := range hostMappingToRemove {
-				_, err := silk.DeleteHostVolumeMapping(h, d.Get("name").(string))
-				if err != nil {
-					return diag.FromErr(err)
-				}
+		// Remove each Host from the Volume
+		for _, h := range hostMappingToRemove {
+			_, err := silk.DeleteHostVolumeMapping(h, currentVolumeName)
+			if err != nil {
+				return diag.FromErr(err)
 			}
 		}
 
@@ -347,41 +358,30 @@ func resourceSilkVolumeUpdate(ctx context.Context, d *schema.ResourceData, m int
 			new = append(new, nReflect.Index(i).Interface().(string))
 		}
 
-		// Mapping Host Group
-		if len(current) < len(new) {
-			// Find all Host Groups that have been added to the host_group_mapping slice
-			for _, hg := range new {
-				_, found := find(current, hg)
-				if !found {
-					hostGroupMappingToAdd = append(hostGroupMappingToAdd, hg)
-				}
+		union := unique(append(current, new... ))
+		for _, h := range union {
+			_, foundInNew := find(new, h)
+			_, foundInCurrent := find(current, h)
+			if foundInNew && !foundInCurrent {
+				hostGroupMappingToRemove = append(hostGroupMappingToRemove, h)
+			} else if !foundInNew && foundInCurrent {
+				hostGroupMappingToRemove = append(hostGroupMappingToRemove, h)
+			} 
+		}
+
+		// Map each Host Group to the Volume
+		for _, hg := range hostGroupMappingToAdd {
+			_, err := silk.CreateHostGroupVolumeMapping(hg, currentVolumeName)
+			if err != nil {
+				return diag.FromErr(err)
 			}
+		}
 
-			// Map each Host Group to the Volume
-			for _, hg := range hostGroupMappingToAdd {
-				_, err := silk.CreateHostGroupVolumeMapping(hg, d.Get("name").(string))
-				if err != nil {
-					return diag.FromErr(err)
-				}
-			}
-
-		} else {
-
-			// Find all Host Group that have been removed from the host_group_mapping slice
-			for _, hg := range current {
-				_, found := find(new, hg)
-				if !found {
-					hostGroupMappingToRemove = append(hostGroupMappingToRemove, hg)
-				}
-			}
-
-			// Remove each Host Group mapping from the Volume
-			for _, hg := range hostGroupMappingToRemove {
-				_, err := silk.DeleteHostGroupVolumeMapping(hg, d.Get("name").(string))
-				if err != nil {
-					return diag.FromErr(err)
-				}
-
+		// Remove each Host Group mapping from the Volume
+		for _, hg := range hostGroupMappingToRemove {
+			_, err := silk.DeleteHostGroupVolumeMapping(hg, currentVolumeName)
+			if err != nil {
+				return diag.FromErr(err)
 			}
 		}
 
@@ -396,10 +396,15 @@ func resourceSilkVolumeUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		volumeGroupConfig := map[string]interface{}{}
-		volumeGroupConfig["ref"] = fmt.Sprintf("/volume_groups/%d", volumeGroupID)
 
-		config["volume_group"] = volumeGroupConfig
+		cGroupID_Interface,_ := d.GetChange("volume_group_id")
+		cGroupID := cGroupID_Interface.(int)
+		if volumeGroupID != cGroupID {
+			d.Set("volume_group_id",volumeGroupID)
+			volumeGroupConfig := map[string]interface{}{}
+			volumeGroupConfig["ref"] = fmt.Sprintf("/volume_groups/%d", volumeGroupID)
+			config["volume_group"] = volumeGroupConfig
+		}
 	}
 
 	if d.HasChange("vmware") {
@@ -418,8 +423,9 @@ func resourceSilkVolumeUpdate(ctx context.Context, d *schema.ResourceData, m int
 	// The update function can be triggered when only the allow_destroy option has been changed.
 	// Since that does not require and update to Silk, skip the UpdateVolume() call.
 	if len(config) != 0 {
-		_, err := silk.UpdateVolume(volumeName, config, timeout)
+		_, err := silk.UpdateVolume(currentVolumeName, config, timeout)
 		if err != nil {
+			d.Set("name",currentVolumeName)
 			return diag.FromErr(err)
 		}
 

--- a/silk/resource_silk_volume.go
+++ b/silk/resource_silk_volume.go
@@ -440,6 +440,28 @@ func resourceSilkVolumeDelete(ctx context.Context, d *schema.ResourceData, m int
 
 	silk := m.(*silksdp.Credentials)
 
+	// Delete host_mappings before remove volume
+	currentHostMappings, _ := d.GetChange("host_mapping")
+	currentHostMappingsReflect := reflect.ValueOf(currentHostMappings)
+	for i := 0; i < currentHostMappingsReflect.Len(); i++ {
+		hostMappingToRemove := currentHostMappingsReflect.Index(i).Interface().(string)
+		_, err := silk.DeleteHostVolumeMapping(hostMappingToRemove, d.Get("name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Delete host_group_mappings before remove volume
+	currentHostGroupMappings, _ := d.GetChange("host_group_mapping")
+	currentHostGroupMappingsReflect := reflect.ValueOf(currentHostGroupMappings)
+	for i := 0; i < currentHostGroupMappingsReflect.Len(); i++ {
+		hostGroupMappingToRemove := currentHostGroupMappingsReflect.Index(i).Interface().(string)
+		_, err := silk.DeleteHostGroupVolumeMapping(hostGroupMappingToRemove, d.Get("name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	_, err := silk.DeleteVolume(name)
 	if err != nil {
 		return diag.FromErr(err)

--- a/silk/resource_silk_volume_group.go
+++ b/silk/resource_silk_volume_group.go
@@ -165,16 +165,16 @@ func resourceSilkVolumeGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 	timeout := d.Get("timeout").(int)
 
 	config := map[string]interface{}{}
-	var volumeGroupName string
+	var currentVolumeGroupName string
 
 	if d.HasChange("name") {
 		config["name"] = d.Get("name").(string)
 		// If the name changed in Terraform, we need to look up the "original" name (i.e what is currently is on the Silk server)
 		// to push the new name change to the volume
-		currentVolumeGroupName, _ := d.GetChange("name")
-		volumeGroupName = currentVolumeGroupName.(string)
+		oldVolumeGroupName, _ := d.GetChange("name")
+		currentVolumeGroupName = oldVolumeGroupName.(string)
 	} else {
-		volumeGroupName = d.Get("name").(string)
+		currentVolumeGroupName = d.Get("name").(string)
 	}
 
 	if d.HasChange("quota_in_gb") {
@@ -193,8 +193,9 @@ func resourceSilkVolumeGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 		config["capacityPolicy"] = d.Get("capacity_policy").(bool)
 	}
 
-	_, err := silk.UpdateVolumeGroup(volumeGroupName, config, timeout)
+	_, err := silk.UpdateVolumeGroup(currentVolumeGroupName, config, timeout)
 	if err != nil {
+		d.Set("name",currentVolumeGroupName)
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
I've reviewed the Terraform modules and discovered some serious issues. Mainly when I started to remove objects with Terraform things went bad pretty quickly. This merge request includes a lot of fixes for those issues. All changes have been tested as much as possible. Bellow you have an overview of all the tests I did. Just be aware that I prefer to have some validation/testing from Silk before I consider this production ready. Also some of the modules were out-of-scope for me. So it would be nice if someone else (Silk?) can have a look at those. 

The updated Terraform modules also require some changes in the go-sdk. For those changes check the merge request:  [https://github.com/silk-us/silk-sdp-go-sdk/pull/3](https://github.com/silk-us/silk-sdp-go-sdk/pull/3)

List of tests:

- Add host to host group
- Duplicate volumes in diffrent volume groups -> returns error
- Duplicate volumes in same volume group -> returns error
- Manually remove a volume from a volume group and let TF fix it
- Map hosts (which also belong to a hostgroup) to a volume or volumegroup -> fail without damaging state file (When a host belongs to a group, it is not allowed to map the individual host to a volume or volume group)
- Map multiple single hosts to 1 volumegroup
- Map volume to multiple hosts in diffrent hostgroups
- Mount volume to multiple hosts in diffrent hostgroup
- Move Volume to another volumegroup (without volume maps)
- Remove volume and volumegroup all in 1 go
- Remove volume group from host group
- Remove volume without setting the allow_destroy parameter -> you get an error during the apply
- Remove host from host group
- Remove hostgroup without removing the hosts and the connected volumes, meaning unmap first before remove
- Rename volume
- Rename volume and volumegroup in single run
- Rename volume group
- Rename single host
- Rename host which belongs to a hostgroup

Kind Regards
Sander Descamps